### PR TITLE
Removed french translations for language names from PO files

### DIFF
--- a/view_breadcrumbs/locale/fr/LC_MESSAGES/django.po
+++ b/view_breadcrumbs/locale/fr/LC_MESSAGES/django.po
@@ -20,11 +20,11 @@ msgstr ""
 
 #: conftest.py:28
 msgid "English"
-msgstr "Anglaise"
+msgstr ""
 
 #: conftest.py:29
 msgid "French"
-msgstr "Français"
+msgstr ""
 
 #: custom/models.py:11
 msgid "library"


### PR DESCRIPTION
Hi,

I propose to remove the french translations for language name from your shipped PO files.

I did so because your translation override the one shipped within Django which already translate these language names. For French language the translation "Français" is accurate but finally the same in Django, but in particular for English language, the french translation should be "Anglais" not "Anglaise", like within Django.

It seems important because since your translation override the Django ones, i noticed your translation for "English" when testing a local project and saw the translation "Anglaise" in my language menu, it was a little disturbing.

I runned the tests and it does not failed anything.
