### PR TITLE
standardized/modernized view mixins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,14 @@
 .idea/
 __pycache__
 .pytest_cache
+*.pytest-deps
 *.pyc
 .tox/
 build/
 dist/
 
 *.db
+*.log
 
 .DS_Store
 .coverage

--- a/view_breadcrumbs/generic/create.py
+++ b/view_breadcrumbs/generic/create.py
@@ -29,10 +29,16 @@ class CreateBreadcrumbMixin(ListBreadcrumbMixin):
         return reverse(self.__create_view_name)
 
     @property
+    def create_view_label(self):
+        if self.add_format_string:
+            return self.add_format_string % {"model": self.model_name_title}
+        return _("Add %(model)s") % {"model": self.model_name_title}
+
+    @property
     def crumbs(self):
         return super(CreateBreadcrumbMixin, self).crumbs + [
             (
-                _(self.add_format_string % {"model": self.model_name_title}),
+                self.create_view_label,
                 self.create_view_url,
             ),
         ]

--- a/view_breadcrumbs/generic/delete.py
+++ b/view_breadcrumbs/generic/delete.py
@@ -1,10 +1,15 @@
 from django.urls import reverse
+from django.utils.encoding import force_str
+from django.utils.translation import gettext_lazy as _
 
 from ..utils import action_view_name, classproperty
-from .list import ListBreadcrumbMixin
+from .detail import DetailBreadcrumbMixin
 
 
-class DeleteBreadcrumbMixin(ListBreadcrumbMixin):
+class DeleteBreadcrumbMixin(DetailBreadcrumbMixin):
+    # Home / object List / object / Delete object
+    delete_format_string = _("Delete %(instance)s")
+
     @classproperty
     def delete_view_name(self):
         return action_view_name(
@@ -30,3 +35,17 @@ class DeleteBreadcrumbMixin(ListBreadcrumbMixin):
             self.__delete_view_name,
             kwargs={self.slug_url_kwarg: getattr(instance, self.slug_field)},
         )
+
+    def delete_view_label(self, instance):
+        if self.delete_format_string:
+            return self.delete_format_string % {'instance': force_str(instance)}
+        return _("Delete %(instance)s") % {'instance': force_str(instance)}
+
+    @property
+    def crumbs(self):
+        return super(DeleteBreadcrumbMixin, self).crumbs + [
+            (
+                self.delete_view_label,
+                self.delete_view_url,
+            ),
+        ]

--- a/view_breadcrumbs/generic/delete.py
+++ b/view_breadcrumbs/generic/delete.py
@@ -38,8 +38,8 @@ class DeleteBreadcrumbMixin(DetailBreadcrumbMixin):
 
     def delete_view_label(self, instance):
         if self.delete_format_string:
-            return self.delete_format_string % {'instance': force_str(instance)}
-        return _("Delete %(instance)s") % {'instance': force_str(instance)}
+            return self.delete_format_string % {"instance": force_str(instance)}
+        return _("Delete %(instance)s") % {"instance": force_str(instance)}
 
     @property
     def crumbs(self):

--- a/view_breadcrumbs/generic/detail.py
+++ b/view_breadcrumbs/generic/detail.py
@@ -1,20 +1,12 @@
-from functools import partial
-
-from django.urls import reverse
 from django.utils.encoding import force_str
-from django.utils.translation import gettext_lazy as _
 
 from ..utils import action_view_name, classproperty
 from .list import ListBreadcrumbMixin
 
 
-def _detail_view_label(instance, format_string):
-    return _(force_str(format_string) % {"instance": force_str(instance)})
-
-
 class DetailBreadcrumbMixin(ListBreadcrumbMixin):
     # Home / object List / str(object)
-    detail_format_string = _("%(instance)s")
+    detail_format_string = "%s"
 
     @classproperty
     def detail_view_name(self):
@@ -32,21 +24,18 @@ class DetailBreadcrumbMixin(ListBreadcrumbMixin):
         )
 
     def detail_view_url(self, instance):
-        if self.breadcrumb_use_pk:
-            return reverse(
-                self.__detail_view_name, kwargs={self.pk_url_kwarg: instance.pk}
-            )
+        return instance.get_absolute_url()
 
-        return reverse(
-            self.__detail_view_name,
-            kwargs={self.slug_url_kwarg: getattr(instance, self.slug_field)},
-        )
+    def detail_view_label(self, instance):
+        if self.detail_format_string:
+            return self.detail_format_string % force_str(instance)
+        return force_str(instance)
 
     @property
     def crumbs(self):
         return super(DetailBreadcrumbMixin, self).crumbs + [
             (
-                partial(_detail_view_label, format_string=self.detail_format_string),
+                self.detail_view_label,
                 self.detail_view_url,
             ),
         ]

--- a/view_breadcrumbs/generic/list.py
+++ b/view_breadcrumbs/generic/list.py
@@ -27,5 +27,9 @@ class ListBreadcrumbMixin(BaseModelBreadcrumbMixin):
         return reverse(self.__list_view_name)
 
     @property
+    def list_view_label(self):
+        return self.model_name_title_plural
+
+    @property
     def crumbs(self):
-        return [(self.model_name_title_plural, self.list_view_url)]
+        return [(self.list_view_label, self.list_view_url)]

--- a/view_breadcrumbs/generic/update.py
+++ b/view_breadcrumbs/generic/update.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
@@ -14,7 +12,7 @@ def _update_view_label(instance, format_string):
 
 class UpdateBreadcrumbMixin(DetailBreadcrumbMixin):
     # Home / object List / object / Update object
-    update_format_str = _("Update: %(instance)s")
+    update_format_string = _("Update %(instance)s")
 
     @classproperty
     def update_view_name(self):
@@ -42,11 +40,16 @@ class UpdateBreadcrumbMixin(DetailBreadcrumbMixin):
             kwargs={self.slug_url_kwarg: getattr(instance, self.slug_field)},
         )
 
+    def update_view_label(self, instance):
+        if self.update_format_string:
+            return self.update_format_string % {'instance': force_str(instance)}
+        return _("Update %(instance)s") % {'instance': force_str(instance)}
+
     @property
     def crumbs(self):
         return super(UpdateBreadcrumbMixin, self).crumbs + [
             (
-                partial(_update_view_label, format_string=self.update_format_str),
+                self.update_view_label,
                 self.update_view_url,
             ),
         ]

--- a/view_breadcrumbs/generic/update.py
+++ b/view_breadcrumbs/generic/update.py
@@ -42,8 +42,8 @@ class UpdateBreadcrumbMixin(DetailBreadcrumbMixin):
 
     def update_view_label(self, instance):
         if self.update_format_string:
-            return self.update_format_string % {'instance': force_str(instance)}
-        return _("Update %(instance)s") % {'instance': force_str(instance)}
+            return self.update_format_string % {"instance": force_str(instance)}
+        return _("Update %(instance)s") % {"instance": force_str(instance)}
 
     @property
     def crumbs(self):

--- a/view_breadcrumbs/templatetags/view_breadcrumbs.py
+++ b/view_breadcrumbs/templatetags/view_breadcrumbs.py
@@ -4,7 +4,6 @@
     :contact: l.mierzwa@gmail.com
 """
 
-
 from __future__ import unicode_literals
 
 import logging


### PR DESCRIPTION
The primary change on this commit is adding a method to each mixin that returns the crumb label. This allows for more granular control of crumb labeling and in the same spirit of the control one has over the crumb URL. Additionally, the URL retrieval for the detail view was changed to `instance.get_absolute_url()`, since that really is best practice and ought to be used where applicable.